### PR TITLE
Fix the OpenSSL version to 1.0.2 for libPocoCrypto fix - Fix #29

### DIFF
--- a/framework/conda_build_config.yaml
+++ b/framework/conda_build_config.yaml
@@ -53,6 +53,8 @@ tbb:
   - 2018_20170919
 librdkafka:
   - 0.11
+openssl:
+  - 1.0.2
 
 zip_keys:
   - python
@@ -87,6 +89,8 @@ pin_run_as_build:
   tbb:
     max_pin: x.x
   librdkafka:
+    max_pin: x.x
+  openssl:
     max_pin: x.x
 #  muparser:
 #    max_pin: x.x

--- a/framework/meta.yaml
+++ b/framework/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - tbb       {{ tbb }}
     - librdkafka  {{ librdkafka }}
     - readline
-    - openssl
+    - openssl   {{ openssl }}
     - python-dateutil
     - h5py
     - mpi4py


### PR DESCRIPTION
In trying to fix #29, I just pinned the max version of OpenSSL and built without issue afterwards using the same build script referenced in the issues.