### PR TITLE
Remove mantid channel to force poco + nexus from conda-forge

### DIFF
--- a/build_framework.sh
+++ b/build_framework.sh
@@ -19,7 +19,6 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
- - mantid
  - defaults
 
 conda-build:

--- a/build_workbench_and_upload.sh
+++ b/build_workbench_and_upload.sh
@@ -17,7 +17,6 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
- - mantid
  - defaults
 
 conda-build:

--- a/systemtest_framework.sh
+++ b/systemtest_framework.sh
@@ -51,7 +51,6 @@ echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc
 . ~/.bashrc
 conda config --set always_yes yes
 conda config --add channels conda-forge
-conda config --add channels mantid
 
 # Setup the conda environment
 ENV="mantid-systemtests"


### PR DESCRIPTION
Related to Issue #13, trying to move to conda-forge dependencies for poco and nexus