### PR TITLE
Pinning _openmp_mutex to gnu, avoids llvm

### DIFF
--- a/framework/conda_build_config.yaml
+++ b/framework/conda_build_config.yaml
@@ -7,3 +7,5 @@ boost:
 numpy:
   - 1.15
 
+_openmp_mutex:
+  - 4.5 1_gnu

--- a/framework/meta.yaml
+++ b/framework/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 requirements:
   build:
-    - _openmp_mutex {{ _openmp_mutex }}
+    - _openmp_mutex {{ _openmp_mutex }} [linux64]
     - boost {{ boost }} 
     - cmake
     - eigen
@@ -34,7 +34,7 @@ requirements:
     - tbb-devel
 
   run:
-    - _openmp_mutex {{ _openmp_mutex }}
+    - _openmp_mutex {{ _openmp_mutex }} [linux64]
     - boost {{ boost }}
     - h5py
     - librdkafka

--- a/framework/meta.yaml
+++ b/framework/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 requirements:
   build:
-    - boost {{ boost }}
+    - _openmp_mutex {{ _openmp_mutex }}
+    - boost {{ boost }} 
     - cmake
     - eigen
     - gsl

--- a/framework/meta.yaml
+++ b/framework/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - tbb-devel
 
   run:
+    - _openmp_mutex {{ _openmp_mutex }}
     - boost {{ boost }}
     - h5py
     - librdkafka


### PR DESCRIPTION
Found this to fix the error I (and the build servers) have been seeing:
```
...
01:24:47 [249/1879] Linking CXX executable bin/MantidNexusParallelLoader
01:24:47 FAILED: bin/MantidNexusParallelLoader 
01:24:47 : && $PREFIX/bin/x86_64-conda_cos6-linux-gnu-c++ -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem $PREFIX/include -fdebug-prefix-map=$SRC_DIR=/usr/local/src/conda/mantid-framework-5.1.20210106.1811 -fdebug-prefix-map=$PREFIX=/usr/local/src/conda-prefix -O3 -DNDEBUG -Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,--disable-new-dtags -Wl,--gc-sections -Wl,-rpath,$PREFIX/lib -Wl,-rpath-link,$PREFIX/lib -L$PREFIX/lib -Wl,--disable-new-dtags Framework/Parallel/CMakeFiles/EventParallelLoader.dir/src/Communicator.cpp.o Framework/Parallel/CMakeFiles/EventParallelLoader.dir/src/ExecutionMode.cpp.o Framework/Parallel/CMakeFiles/EventParallelLoader.dir/src/IO/Chunker.cpp.o Framework/Parallel/CMakeFiles/EventParallelLoader.dir/src/IO/EventLoader.cpp.o Framework/Parallel/CMakeFiles/EventParallelLoader.dir/src/IO/EventParser.cpp.o Framework/Parallel/CMakeFiles/EventParallelLoader.dir/src/IO/EventsListsShmemManager.cpp.o Framework/Parallel/CMakeFiles/EventParallelLoader.dir/src/IO/EventsListsShmemStorage.cpp.o Framework/Parallel/CMakeFiles/EventParallelLoader.dir/src/IO/MultiProcessEventLoader.cpp.o Framework/Parallel/CMakeFiles/EventParallelLoader.dir/src/IO/NXEventDataLoader.cpp.o Framework/Parallel/CMakeFiles/EventParallelLoader.dir/src/IO/EventLoaderChild.cpp.o Framework/Parallel/CMakeFiles/EventParallelLoader.dir/src/Request.cpp.o Framework/Parallel/CMakeFiles/EventParallelLoader.dir/src/StorageMode.cpp.o Framework/Parallel/CMakeFiles/EventParallelLoader.dir/src/ThreadingBackend.cpp.o Framework/Parallel/CMakeFiles/EventParallelLoader.dir/src/IO/EventLoaderHelpers.cpp.o -o bin/MantidNexusParallelLoader  -Wl,-rpath,$SRC_DIR/build/bin:  $PREFIX/lib/libgsl.so  $PREFIX/lib/libgslcblas.so  $PREFIX/lib/libboost_date_time.so  $PREFIX/lib/libboost_regex.so  $PREFIX/lib/libboost_serialization.so  $PREFIX/lib/libboost_filesystem.so  $PREFIX/lib/libboost_system.so  $PREFIX/lib/libPocoFoundation.so  $PREFIX/lib/libPocoUtil.so  $PREFIX/lib/libPocoXML.so  $PREFIX/lib/libPocoNet.so  $PREFIX/lib/libPocoCrypto.so  $PREFIX/lib/libPocoNetSSL.so  $PREFIX/lib/libhdf5_cpp.so  $PREFIX/lib/libhdf5.so  bin/libMantidKernel.so  -lrt  bin/libMantidTypes.so  $PREFIX/lib/libboost_date_time.so  $PREFIX/lib/libboost_regex.so  $PREFIX/lib/libboost_serialization.so  $PREFIX/lib/libboost_filesystem.so  $PREFIX/lib/libboost_system.so  $PREFIX/lib/libNeXus.so  $PREFIX/lib/libNeXusCPP.so  $PREFIX/lib/libjsoncpp.so  -ltbb  -ltbbmalloc && :
01:24:47 $PREFIX/bin/../lib/gcc/x86_64-conda_cos6-linux-gnu/7.3.0/../../../../x86_64-conda_cos6-linux-gnu/bin/ld: Framework/Parallel/CMakeFiles/EventParallelLoader.dir/src/IO/EventsListsShmemManager.cpp.o: undefined reference to symbol 'pthread_mutexattr_settype@@GLIBC_2.2.5'
01:24:47 $PREFIX/bin/../lib/gcc/x86_64-conda_cos6-linux-gnu/7.3.0/../../../../x86_64-conda_cos6-linux-gnu/bin/ld: $PREFIX/bin/../x86_64-conda_cos6-linux-gnu/sysroot/lib/libpthread.so.0: error adding symbols: DSO missing from command line
01:24:47 collect2: error: ld returned 1 exit status
```

Just pinning to a `gnu` version of `_openmp_mutex`.
Seems that when we land on a `llvm` version of `_openmp_mutex` we get the above error.

@OwenArnold mainly adding you to see if you can test this works on Mac. Thanks!
Notify: @peterfpeterson 