### PR TITLE
missing pre-commit

### DIFF
--- a/framework/meta.yaml
+++ b/framework/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - poco
     - python {{ python }}
     - tbb-devel
+    - pre-commit
 
   run:
     - _openmp_mutex {{ _openmp_mutex }} [linux64]


### PR DESCRIPTION
Did not get updated following https://github.com/mantidproject/mantid/pull/30740

This is the reason the framework conda builds have been failing for some days.