### PR TITLE
Update numpy pinning

### DIFF
--- a/recipes/mantid/meta.yaml
+++ b/recipes/mantid/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - {{ pin_compatible("hdf5", max_pin="x.x") }}
     - lib3mf  # [win]
     - nexus
-    - {{ pin_compatible("numpy") }}
+    - numpy >={{ numpy }},<=1.22.3|>=1.23
     - {{ pin_compatible("occt", max_pin="x.x.x") }}
     - python
     - python-dateutil


### PR DESCRIPTION
Numpy 1.22.4 is casuing problems with quasielastic bayes, so we will avoid it for now. See here:
https://github.com/mantidproject/mantid/issues/33978