### PR TITLE
Revert "Update numpy pinning"

### DIFF
--- a/recipes/mantid/meta.yaml
+++ b/recipes/mantid/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - {{ pin_compatible("hdf5", max_pin="x.x") }}
     - lib3mf  # [win]
     - nexus
-    - numpy >={{ numpy }},<=1.22.3|>=1.23
+    - {{ pin_compatible("numpy") }}
     - {{ pin_compatible("occt", max_pin="x.x.x") }}
     - python
     - python-dateutil


### PR DESCRIPTION
Reverts mantidproject/conda-recipes#70

The error with using numpy 1.22.4 and mantid was fixed in mantidproject/mantid#33996 so this pin can now be reverted.