### PR TITLE
Add Euphonic dependency

### DIFF
--- a/recipes/mantid/meta.yaml
+++ b/recipes/mantid/meta.yaml
@@ -62,6 +62,7 @@ requirements:
     - pyyaml
     - scipy
     - openssl {{ openssl }}
+    - euphonic=0.6.*
 
 about:
   home: https://github.com/mantidproject/mantid


### PR DESCRIPTION
Euphonic library used by Abins and DensityOfStates routines. This is already present in the _mantid-developer-X.yml_ files but not currently shipped with the Conda builds.

Here Euphonic is pinned to version 0.6.*; versions >= 1.0 contain breaking API changes.
We'll need to figure out an appropriate way of updating the Mantid code and conda recipe at the same time when it comes to making those updates. It wouldn't be very difficult to create an intermediate Mantid version compatible with both, but it would be nice not to have that logic hanging around in a stable release (and simplify the testing situation).