### PR TITLE
Pin sphinx to fix imaging linking of latex math

### DIFF
--- a/recipes/conda_build_config.yaml
+++ b/recipes/conda_build_config.yaml
@@ -33,6 +33,9 @@ openssl:
 setuptools:
   - 48.0.*
 
+sphinx:
+  - 5.1.1
+
 qt:
   - 5.12.*
 

--- a/recipes/mantiddocs/meta.yaml
+++ b/recipes/mantiddocs/meta.yaml
@@ -30,7 +30,7 @@ requirements:
   host:
     - python
     - setuptools {{ setuptools }}
-    - sphinx
+    - sphinx {{ sphinx }}
     - sphinx_bootstrap_theme
     - mantidqt {{ version }}
 


### PR DESCRIPTION
At some point after [Sphinx 5.1.1](https://www.sphinx-doc.org/en/master/changes.html) the `math:` links generated by Sphinx.ext.imgmath were broken. The images themselves are generated correctly but the `href` created in the html is invalid.