### PR TITLE
Revert "Add a pin for sphinx_bootstrap_theme"

### DIFF
--- a/recipes/conda_build_config.yaml
+++ b/recipes/conda_build_config.yaml
@@ -35,9 +35,6 @@ setuptools:
 
 sphinx:
   - 5.1.1
-  
-sphinx_bootstrap_theme:
-  - >0.8.0
 
 qt:
   - 5.12.*

--- a/recipes/mantiddocs/meta.yaml
+++ b/recipes/mantiddocs/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - python
     - setuptools {{ setuptools }}
     - sphinx {{ sphinx }}
-    - sphinx_bootstrap_theme {{ sphinx_bootstrap_theme }}
+    - sphinx_bootstrap_theme
     - mantidqt {{ version }}
 
 # there are no run requirements as it's just pure html


### PR DESCRIPTION
Reverts mantidproject/conda-recipes#79

There is an issue with the syntax:
```
14:23:52      raise ScannerError("while scanning a block scalar", start_mark,
14:23:52  yaml.scanner.ScannerError: while scanning a block scalar
14:23:52    in "<unicode string>", line 32, column 5:
14:23:52        - >0.8.0
14:23:52          ^
14:23:52  expected indentation indicator in the range 1-9, but found 0
14:23:52    in "<unicode string>", line 32, column 6:
14:23:52        - >0.8.0
```
