### PR TITLE
Change bootstrap pinning

### DIFF
--- a/recipes/conda_build_config.yaml
+++ b/recipes/conda_build_config.yaml
@@ -36,6 +36,9 @@ setuptools:
 sphinx:
   - 5.1.1
 
+sphinx_bootstrap_theme:
+  - 0.8.1
+
 qt:
   - 5.12.*
 


### PR DESCRIPTION
It has not been possible to pin using greater than or equals and so I have just put a pin in for v0.8.1 of sphinx_bootstrap_pinning.

*To test*
The following build should begin successfully
https://builds.mantidproject.org/job/build_packages_from_branch/112/

(please note the build did fall over but due to a merge on the main branch which will be solved in the future by this PR - https://github.com/mantidproject/mantid/pull/34617. However it did not have a problem with the new pin.)