### PR TITLE
Add pycifrw to the runtime dependencies

### DIFF
--- a/recipes/conda_build_config.yaml
+++ b/recipes/conda_build_config.yaml
@@ -57,6 +57,12 @@ gsl:
 ipykernel:
   - <6
 
+euphonic:
+  - 0.6.*
+
+pycifrw:
+  - 4.4.1
+
 pin_run_as_build:
     boost:
       max_pin: x.x

--- a/recipes/mantid/meta.yaml
+++ b/recipes/mantid/meta.yaml
@@ -57,6 +57,7 @@ requirements:
     - nexus
     - {{ pin_compatible("numpy") }}
     - {{ pin_compatible("occt", max_pin="x.x.x") }}
+    - pycifrw=4.4.1 # Force to 4.4.1 as later versions cause issues with loading CIF files
     - python
     - python-dateutil
     - pyyaml

--- a/recipes/mantid/meta.yaml
+++ b/recipes/mantid/meta.yaml
@@ -57,13 +57,13 @@ requirements:
     - nexus
     - {{ pin_compatible("numpy") }}
     - {{ pin_compatible("occt", max_pin="x.x.x") }}
-    - pycifrw=4.4.1 # Force to 4.4.1 as later versions cause issues with loading CIF files
+    - pycifrw {{ pycifrw }}
     - python
     - python-dateutil
     - pyyaml
     - scipy
     - openssl {{ openssl }}
-    - euphonic=0.6.*
+    - euphonic {{ euphonic }}
     - toml
 
 about:


### PR DESCRIPTION
[pycifrw](https://anaconda.org/conda-forge/pycifrw) is used by the `LoadCIF` algorithm, but isn't in the runtime dependencies.