### PR TITLE
Update Qt to 5.15

### DIFF
--- a/recipes/conda_build_config.yaml
+++ b/recipes/conda_build_config.yaml
@@ -28,7 +28,7 @@ matplotlib:
   - 3.5.*
 
 openssl:
-  - 1.1.1l
+  - 1.1.*
 
 setuptools:
   - 48.0.*

--- a/recipes/conda_build_config.yaml
+++ b/recipes/conda_build_config.yaml
@@ -42,6 +42,9 @@ sphinx_bootstrap_theme:
 qt:
   - 5.15.*
 
+qscintilla2:
+  - 2.13.*
+
 tbb:
   - 2020.2.*
 

--- a/recipes/conda_build_config.yaml
+++ b/recipes/conda_build_config.yaml
@@ -40,7 +40,7 @@ sphinx_bootstrap_theme:
   - 0.8.1
 
 qt:
-  - 5.12.*
+  - 5.15.*
 
 tbb:
   - 2020.2.*

--- a/recipes/mantidqt/meta.yaml
+++ b/recipes/mantidqt/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - python
     - pyqt
     - qt {{ qt }}
-    - qscintilla2
+    - qscintilla2 {{ qscintilla2 }}
     - setuptools {{ setuptools }}
     - tbb-devel {{ tbb }}
 


### PR DESCRIPTION
In line with changes to mantid in mantidproject/mantid#34808, update Qt dependencies in Conda as Qt 5.15 is now a minimum. See the linked PR for testing instructions. This must be merged at the same time as that PR.