### PR TITLE
Temporarily pin numpy to stop failures

### DIFF
--- a/recipes/conda_build_config.yaml
+++ b/recipes/conda_build_config.yaml
@@ -22,7 +22,7 @@ boost:
   - 1.77
 
 numpy:
-  - 1.19
+  - 1.23.5
 
 matplotlib:
   - 3.5.*

--- a/recipes/mantid/meta.yaml
+++ b/recipes/mantid/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - lib3mf  # [win]
     - muparser
     - nexus
-    - numpy >={{numpy}},<=1.23.5|>=1.23
+    - numpy {{ numpy }}
     - occt {{ occt }}
     - python {{ python }}
     - poco

--- a/recipes/mantid/meta.yaml
+++ b/recipes/mantid/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - lib3mf  # [win]
     - muparser
     - nexus
-    - numpy {{ numpy }}
+    - numpy >={{numpy}},<=1.23.5|>=1.23
     - occt {{ occt }}
     - python {{ python }}
     - poco


### PR DESCRIPTION
In order to stop failures that have occurred when moving from version 1.23.5 to 1.24.0 of numpy we temporarily need to pin the version.
