### PR TITLE
Fix issue with euphonic (migrate numpy to 1.23 at runtime)

### DIFF
--- a/recipes/conda_build_config.yaml
+++ b/recipes/conda_build_config.yaml
@@ -22,7 +22,7 @@ boost:
   - 1.77
 
 numpy:
-  - 1.19
+  - 1.23.*
 
 matplotlib:
   - 3.5.*

--- a/recipes/mantid/meta.yaml
+++ b/recipes/mantid/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - lib3mf  # [win]
     - muparser
     - nexus
-    - numpy {{ numpy }}
+    - numpy {{ numpy }},<1.24 # Pinned below 1.24 due to the issues with h5py and numpy versioning.
     - occt {{ occt }}
     - python {{ python }}
     - poco
@@ -55,7 +55,7 @@ requirements:
     - {{ pin_compatible("hdf5", max_pin="x.x") }}
     - lib3mf  # [win]
     - nexus
-    - {{ pin_compatible("numpy") }}
+    - {{ pin_compatible("numpy"), max_pin="x.x" }}
     - {{ pin_compatible("occt", max_pin="x.x.x") }}
     - python
     - python-dateutil

--- a/recipes/mantid/meta.yaml
+++ b/recipes/mantid/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - {{ pin_compatible("hdf5", max_pin="x.x") }}
     - lib3mf  # [win]
     - nexus
-    - {{ pin_compatible("numpy"), max_pin="x.x" }}
+    - {{ pin_compatible("numpy"), max_pin="x.x") }}
     - {{ pin_compatible("occt", max_pin="x.x.x") }}
     - python
     - python-dateutil


### PR DESCRIPTION
Currently, Euphonic is designed in a way that it requires NumPy 1.23 or greater at run time, this forces us to move our innings forwards.

However, h5py has an issue with 1.24 by calling previously deprecated public API classes, i.e. np.typeDict which has migrated to np.sctypeDict and has been properly deprecated since 1.20 of NumPy (but theoretically deprecated since 2006). 

A long-term fix is to ensure that euphonic as a package moves in line with conda-forge and the rest of the python community unless it absolutely must move to 1.23+. They vaguely follow NumPy's drop timetable: https://numpy.org/neps/nep-0029-deprecation_policy.html