### PR TITLE
Match conda-forge on tbb/clang

### DIFF
--- a/recipes/conda_build_config.yaml
+++ b/recipes/conda_build_config.yaml
@@ -3,17 +3,17 @@ c_compiler:
   - clang                    # [osx]
   - vs2019                   # [win]
 c_compiler_version:            # [unix]
-  - 13                         # [osx]
+  - 14                         # [osx]
   - 10                         # [linux]
 cxx_compiler:
   - gxx                      # [linux]
   - clangxx                  # [osx]
   - vs2019                   # [win]
 cxx_compiler_version:          # [unix]
-  - 13                         # [osx]
+  - 14                         # [osx]
   - 10                         # [linux]
 llvm_openmp:                   # [osx]
-  - 13                         # [osx]
+  - 14                         # [osx]
 
 python:
   - 3.8
@@ -46,7 +46,7 @@ qscintilla2:
   - 2.13.*
 
 tbb:
-  - 2020.2.*
+  - 2021
 
 hdf5:
   - 1.12.*


### PR DESCRIPTION
Keep pace with recent updates.

VTK depends on tbb so matching
versions allows environments to solve
when hdf5 is added to the mix.
See mantidproject/mantid#34911